### PR TITLE
[1.x] Extend the "order by" query to use more relationship types

### DIFF
--- a/src/Concerns/HasModel.php
+++ b/src/Concerns/HasModel.php
@@ -16,6 +16,13 @@ trait HasModel
     protected $model;
 
     /**
+     * The current model or the related model based on the relationship value.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $modelOrRelation;
+
+    /**
      * The relationship to search in.
      *
      * @var string
@@ -54,6 +61,29 @@ trait HasModel
         }
 
         return $this->model;
+    }
+
+    /**
+     * Get the current model or the related model based on the relationship value.
+     *
+     * @param  string|null  $relationship
+     * @param  \Illuminate\Database\Eloquent\Model|null  $model
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function resolveModelOrRelation($relationship = null, $model = null)
+    {
+        if (!empty($this->modelOrRelation)) {
+            return $this->modelOrRelation;
+        }
+
+        if (!empty($relationship) && !empty($model)) {
+            return empty($relationship) ? $model : $model->{$relationship}()->getRelated();
+        }
+
+        $relationship = $this->getRelationship();
+        $model        = $this->getModel();
+
+        return empty($relationship) ? $model : $model->{$relationship}()->getRelated();
     }
 
     /**
@@ -126,6 +156,7 @@ trait HasModel
      */
     public function usingScopes(array $scopes)
     {
+        // TODO: Add the ability to pass additional arguments to local scopes.
         $localScopes = [];
 
         foreach ($scopes as $scope) {

--- a/src/Concerns/Orderable.php
+++ b/src/Concerns/Orderable.php
@@ -3,6 +3,10 @@
 namespace Ramadan\EasyModel\Concerns;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Ramadan\EasyModel\Exceptions\InvalidArrayStructure;
 
 trait Orderable
@@ -72,9 +76,7 @@ trait Orderable
         if (count($parts) > 1) {
             // In case the order is related to the model relationships, we need to get
             // the relationships and the column that needs to be ordered (e.g., "posts.created_at").
-            $column = implode('.', array_slice($parts, -2));
-
-            $this->performJoinsForOrderByRelationships($parts, $queryBuilder);
+            $column = $this->performJoinsForOrderByRelationships($parts, $queryBuilder);
         }
 
         if (!in_array($direction, ['asc', 'desc'], true)) {
@@ -92,41 +94,52 @@ trait Orderable
      *
      * @param  array  $relationships
      * @param  \Illuminate\Database\Query\Builder  $queryBuilder
-     * @return void
+     * @return string
      */
     protected function performJoinsForOrderByRelationships($relationships, $queryBuilder)
     {
-        $model        = $this->getModel();
-        $relationship = $this->getRelationship();
-        
-        // Let's pretend that the model will get back an instance of "App\Models\User".
-        $currentModel = empty($relationship) ? $model : $model->{$relationship}()->getRelated();
+        $currentModel = $this->resolveModelOrRelation();
 
         for ($i = 0; $i < count($relationships) - 1; $i++) {
-            // This will call the model relationships (e.g., $user->posts(), $user->comments()).
-            $relatedModel = $currentModel->{$relationships[$i]}()->getModel();
+            $currentRelationship = $currentModel->{$relationships[$i]}();
+            $relatedModel        = $currentRelationship->getModel();
 
-            // Get the table name of the current and related models.
-            $currentTableName = $currentModel->getTable();
-            $relatedTableName = $relatedModel->getTable();
+            // At first let's pretend that the current model is "App\Models\User" which is the parent and he has
+            // one or many child models (e.g., "post", "comments") in this case, the foreign key of the current
+            // model is "user_id" and must be exists in the child table(s).
+            if (in_array(get_class($currentRelationship), [HasMany::class, HasOne::class])) {
+                $currentTableName = $currentModel->getTable();
+                $relatedTableName = $relatedModel->getTable();
 
-            // Get the foreign key and primary key of the current model.
-            $currentForeignKey      = $currentModel->getForeignKey();
-            $currentTablePrimaryKey = $currentModel->getKeyName();
+                $currentForeignKey      = $currentModel->getForeignKey();
+                $currentTablePrimaryKey = $currentModel->getKeyName();
+            }
 
-            // Perform the join:
-            // - Current table is the current model's table (for first iteration, it's the "users" table).
-            // - Related table is the related model's table (e.g., "posts").
+            // But, in case the current model is "App\Models\Post" which is the child and it belongs to
+            // a parent model (e.g., "user") the foreign key "user_id" must exists in the table of the
+            // current related model "posts".
+            elseif (in_array(get_class($currentRelationship), [BelongsTo::class, BelongsToMany::class])) {
+                $currentTableName = $relatedModel->getTable();
+                $relatedTableName = $currentModel->getTable();
+
+                $currentForeignKey      = $relatedModel->getForeignKey();
+                $currentTablePrimaryKey = $currentModel->getKeyName();
+            }
+
+            // Perform the join
             $queryBuilder->join(
-                table: $relatedTableName,
+                table: $relatedModel->getTable(),
                 first: "{$currentTableName}.{$currentTablePrimaryKey}",
                 operator: '=',
                 second: "{$relatedTableName}.{$currentForeignKey}"
             );
 
-            // Now, let's move to the next model (the current one will be the related model) hence, if
-            // the current model was "users" then, the current model in the next iteration will be "posts".
+            // Now, let's move to the next model (the current one will be the related model). If the current
+            // model is "users," then the current model in the next iteration will be "posts".
             $currentModel = $relatedModel;
         }
+
+        // The "$currentModel" always contains the latest relationship that you need to use for performing the order
+        return "{$currentModel->getTable()}.{$relationships[count($relationships) - 1]}";
     }
 }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -265,9 +265,9 @@ trait Searchable
         if (empty($this->eloquentBuilder) && !empty($this->queryBuilder)) {
             // When the relationship is provided, we will start a new query and set the model
             // with the given relationship using "getRelated" method on it.
-            $currentModel = empty($relationship) ? $model : $model->{$relationship}()->getRelated();
+            $this->modelOrRelation = $this->resolveModelOrRelation($relationship, $model);
 
-            $this->eloquentBuilder = $currentModel->newQuery()->setQuery($this->queryBuilder);
+            $this->eloquentBuilder = $this->modelOrRelation->newQuery()->setQuery($this->queryBuilder);
         }
 
         if (!empty($this->eloquentBuilder)) {


### PR DESCRIPTION
This PR introduces the following features and improvements:

- Refactors the code.
- Adds the ability to order the query using the `HasOne`, `HasMany`, `BelongsTo`, and `BelongsToMany` relationships.