### PR TITLE
[1.x] Extend the "addWheres" method to accept closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ public function index()
         ->usingScopes([
             // new EmailVerifiedScope, // Global Scope in object
             EmailVerifiedScope::class, // Global Scope in string
-            // 'isAdmin', // Local Scope
-            'isAdmin' => [false], // Local Scope With Parameters
+            // 'isAdmin', // Local Scope Without Parameters
+            'isAdmin' => [false, fn($q) => $q->where('id', '>', 2)], // Local Scope With Parameters
         ])
         ->execute()
         ->get();

--- a/src/Concerns/ShouldBuildQueries.php
+++ b/src/Concerns/ShouldBuildQueries.php
@@ -31,17 +31,14 @@ trait ShouldBuildQueries
      */
     public function buildQueryUsingWheres($wheres, $method = 'where')
     {
-        $this->queryBuilder = $this
-            ->getQueryBuilder()
-            ->whereNested(function ($query) use ($wheres, $method) {
-                foreach ($wheres as $key => $value) {
-                    if (is_numeric($key) && is_array($value)) {
-                        $query->{$method}(...array_values($value));
-                    } else {
-                        $query->{$method}($key, '=', $value, $method === 'where' ? 'and' : 'or');
-                    }
-                }
-            }, $method === 'where' ? 'and' : 'or');
+        $queryBuilder = $this->getQueryBuilder();
+        foreach ($wheres as $where) {
+            $this->{(match (gettype($where)) {
+                'object' => 'prepareClosuresForWheres',
+                'array'  => 'prepareArraysForWheres',
+            })}($where, $queryBuilder, $method);
+        }
+        $this->queryBuilder = $queryBuilder;
 
         return $this;
     }
@@ -230,5 +227,43 @@ trait ShouldBuildQueries
             'operator' => $operator,
             'value'    => $value
         ];
+    }
+
+    /**
+     * Prepare the closures for "where" closure.
+     *
+     * @param \Closure $where
+     * @param \Illuminate\Database\Query\Builder $queryBuilder
+     * @param string $method
+     * @return void
+     */
+    protected function prepareClosuresForWheres($where, $queryBuilder, $method = 'where')
+    {
+        $type    = 'Nested';
+        $where($query = $queryBuilder->forNestedWhere());
+        $boolean = $method === 'where' ? 'and' : 'or';
+
+        $queryBuilder->wheres[] = compact('type', 'query', 'boolean');
+
+        $queryBuilder->addBinding($queryBuilder->getRawBindings()['where'], 'where');
+    }
+
+    /**
+     * Prepare the array for "where" closure.
+     *
+     * @param array $where
+     * @param \Illuminate\Database\Query\Builder $queryBuilder
+     * @param string $method
+     * @return void
+     */
+    protected function prepareArraysForWheres($where, $queryBuilder, $method = 'where')
+    {
+        $queryBuilder->whereNested(function ($query) use ($where, $method) {
+            if (count($where) === 3) {
+                $query->{$method}(...array_values($where), boolean: $method === 'where' ? 'and' : 'or');
+            } else {
+                $query->{$method}($where[0], '=', $where[1], $method === 'where' ? 'and' : 'or');
+            }
+        }, $method === 'where' ? 'and' : 'or');
     }
 }

--- a/src/Concerns/ShouldBuildQueries.php
+++ b/src/Concerns/ShouldBuildQueries.php
@@ -166,6 +166,41 @@ trait ShouldBuildQueries
     }
 
     /**
+     * Prepare a nested of "where" clauses using the given closure.
+     *
+     * @param \Closure $where
+     * @param \Illuminate\Database\Query\Builder $queryBuilder
+     * @param string $method
+     * @return void
+     */
+    protected function prepareClosuresForWheres($where, $queryBuilder, $method = 'where')
+    {
+        $where($query = $queryBuilder->forNestedWhere());
+        $boolean = $method === 'where' ? 'and' : 'or';
+
+        $queryBuilder->addNestedWhereQuery($query, $boolean);
+    }
+
+    /**
+     * Prepare an array of conditions to be inserted into the "where" clause.
+     *
+     * @param array $where
+     * @param \Illuminate\Database\Query\Builder $queryBuilder
+     * @param string $method
+     * @return void
+     */
+    protected function prepareArraysForWheres($where, $queryBuilder, $method = 'where')
+    {
+        $this->prepareClosuresForWheres(function ($query) use ($where, $method) {
+            if (count($where) === 3) {
+                $query->{$method}(...array_values($where), boolean: $method === 'where' ? 'and' : 'or');
+            } else {
+                $query->{$method}($where[0], '=', $where[1], $method === 'where' ? 'and' : 'or');
+            }
+        }, $queryBuilder, $method);
+    }
+
+    /**
      * Prepare the "whereHas", and "whereDoesntHave" parameters.
      *
      * @param  string  $subject
@@ -227,43 +262,5 @@ trait ShouldBuildQueries
             'operator' => $operator,
             'value'    => $value
         ];
-    }
-
-    /**
-     * Prepare the closures for "where" closure.
-     *
-     * @param \Closure $where
-     * @param \Illuminate\Database\Query\Builder $queryBuilder
-     * @param string $method
-     * @return void
-     */
-    protected function prepareClosuresForWheres($where, $queryBuilder, $method = 'where')
-    {
-        $type    = 'Nested';
-        $where($query = $queryBuilder->forNestedWhere());
-        $boolean = $method === 'where' ? 'and' : 'or';
-
-        $queryBuilder->wheres[] = compact('type', 'query', 'boolean');
-
-        $queryBuilder->addBinding($queryBuilder->getRawBindings()['where'], 'where');
-    }
-
-    /**
-     * Prepare the array for "where" closure.
-     *
-     * @param array $where
-     * @param \Illuminate\Database\Query\Builder $queryBuilder
-     * @param string $method
-     * @return void
-     */
-    protected function prepareArraysForWheres($where, $queryBuilder, $method = 'where')
-    {
-        $queryBuilder->whereNested(function ($query) use ($where, $method) {
-            if (count($where) === 3) {
-                $query->{$method}(...array_values($where), boolean: $method === 'where' ? 'and' : 'or');
-            } else {
-                $query->{$method}($where[0], '=', $where[1], $method === 'where' ? 'and' : 'or');
-            }
-        }, $method === 'where' ? 'and' : 'or');
     }
 }

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -75,7 +75,7 @@ trait Searchable
      *
      * @throws \Ramadan\EasyModel\Exceptions\InvalidSearchableModel
      */
-    public function addOrWheres($wheres, EloquentBuilder $query = null)
+    public function addOrWheres(array $wheres, EloquentBuilder $query = null)
     {
         $this->setQuery($query);
 


### PR DESCRIPTION
This PR introduces the following improvements:

- Refactors the code.
- Adds the ability to pass a closure into the `addWheres` and `addOrWheres` methods.