### PR TITLE
[1.x] improvements

### DIFF
--- a/src/Concerns/Search/HasModel.php
+++ b/src/Concerns/Search/HasModel.php
@@ -31,10 +31,10 @@ trait HasModel
     protected $modelOrRelation;
 
     /**
-     * Set the searchable model without chaining the query.
+     * Set the searchable model.
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $model
-     * @return void
+     * @return $this
      *
      * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
      */
@@ -48,6 +48,8 @@ trait HasModel
         }
 
         $this->searchableModel = $model;
+
+        return $this;
     }
 
     /**
@@ -58,21 +60,6 @@ trait HasModel
     protected function getSearchableModel()
     {
         return is_string($this->searchableModel) ? new $this->searchableModel : $this->searchableModel;
-    }
-
-    /**
-     * Set the searchable model then chain the query.
-     *
-     * @param  \Illuminate\Database\Eloquent\Model|string  $model
-     * @return $this
-     *
-     * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
-     */
-    public function setChainableModel($model)
-    {
-        $this->setSearchableModel($model);
-
-        return $this;
     }
 
     /**
@@ -107,7 +94,7 @@ trait HasModel
      */
     protected function resolveModel()
     {
-        // We will check if the model has been set using the "setSearchableModel" or "setChainableModel"
+        // We will check if the model has been set using the "setSearchableModel" or "setSearchableModel"
         // method as a manual setting is more of a priority otherwise it means the developer uses
         // the "Searchable" trait in the model itself.
         if (!empty($this->getSearchableModel())) {

--- a/src/Concerns/Update/HasModel.php
+++ b/src/Concerns/Update/HasModel.php
@@ -18,7 +18,7 @@ trait HasModel
      * Set the updatable model.
      *
      * @param  \Illuminate\Database\Eloquent\Model|string  $model
-     * @return void
+     * @return $this
      *
      * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
      */
@@ -32,6 +32,8 @@ trait HasModel
         }
 
         $this->updatableModel = $model;
+
+        return $this;
     }
 
     /**

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -51,9 +51,9 @@ trait Searchable
      */
     public function addWheres(array $wheres, EloquentBuilder $query = null)
     {
-        $this->setQuery($query);
-
-        return $this->buildQueryUsingWheres($wheres);
+        return $this
+            ->setSearchableQuery($query)
+            ->buildQueryUsingWheres($wheres);
     }
 
     /**
@@ -67,9 +67,9 @@ trait Searchable
      */
     public function addOrWheres(array $wheres, EloquentBuilder $query = null)
     {
-        $this->setQuery($query);
-
-        return $this->buildQueryUsingWheres($wheres, 'orWhere');
+        return $this
+            ->setSearchableQuery($query)
+            ->buildQueryUsingWheres($wheres, 'orWhere');
     }
 
     /**
@@ -90,9 +90,9 @@ trait Searchable
         array $relation = [],
         EloquentBuilder $query = null
     ) {
-        $this->setQuery($query);
-
-        return $this->buildQueryUsingRelationConditions($has, $doesntHave, $relation);
+        return $this
+            ->setSearchableQuery($query)
+            ->buildQueryUsingRelationConditions($has, $doesntHave, $relation);
     }
 
     /**
@@ -113,9 +113,9 @@ trait Searchable
         array $relation = [],
         EloquentBuilder $query = null
     ) {
-        $this->setQuery($query);
-
-        return $this->buildQueryUsingRelationConditions($has, $doesntHave, $relation, 'orWhere');
+        return $this
+            ->setSearchableQuery($query)
+            ->buildQueryUsingRelationConditions($has, $doesntHave, $relation, 'orWhere');
     }
 
     /**
@@ -130,11 +130,9 @@ trait Searchable
      */
     public function addWhereHas(array $wheres, EloquentBuilder $query = null)
     {
-        $this->setQuery($query);
-
-        $this->buildQueryUsingWhereHasAndDoesntHave($wheres);
-
-        return $this;
+        return $this
+            ->setSearchableQuery($query)
+            ->buildQueryUsingWhereHasAndDoesntHave($wheres);
     }
 
     /**
@@ -149,11 +147,9 @@ trait Searchable
      */
     public function addOrWhereHas(array $wheres, EloquentBuilder $query = null)
     {
-        $this->setQuery($query);
-
-        $this->buildQueryUsingWhereHasAndDoesntHave($wheres, 'orWhereHas');
-
-        return $this;
+        return $this
+            ->setSearchableQuery($query)
+            ->buildQueryUsingWhereHasAndDoesntHave($wheres, 'orWhereHas');
     }
 
     /**
@@ -168,11 +164,9 @@ trait Searchable
      */
     public function addWhereDoesntHave(array $wheres, EloquentBuilder $query = null)
     {
-        $this->setQuery($query);
-
-        $this->buildQueryUsingWhereHasAndDoesntHave($wheres, 'whereDoesntHave');
-
-        return $this;
+        return $this
+            ->setSearchableQuery($query)
+            ->buildQueryUsingWhereHasAndDoesntHave($wheres, 'whereDoesntHave');
     }
 
     /**
@@ -187,11 +181,9 @@ trait Searchable
      */
     public function addOrWhereDoesntHave(array $wheres, EloquentBuilder $query = null)
     {
-        $this->setQuery($query);
-
-        $this->buildQueryUsingWhereHasAndDoesntHave($wheres, 'orWhereDoesntHave');
-
-        return $this;
+        return $this
+            ->setSearchableQuery($query)
+            ->buildQueryUsingWhereHasAndDoesntHave($wheres, 'orWhereDoesntHave');
     }
 
     /**
@@ -206,11 +198,9 @@ trait Searchable
      */
     public function addWhereRelation(array $wheres, EloquentBuilder $query = null)
     {
-        $this->setQuery($query);
-
-        $this->buildQueryUsingWhereRelation($wheres, 'whereRelation');
-
-        return $this;
+        return $this
+            ->setSearchableQuery($query)
+            ->buildQueryUsingWhereRelation($wheres, 'whereRelation');
     }
 
     /**
@@ -225,11 +215,9 @@ trait Searchable
      */
     public function addOrWhereRelation(array $wheres, EloquentBuilder $query = null)
     {
-        $this->setQuery($query);
-
-        $this->buildQueryUsingWhereRelation($wheres, 'orWhereRelation');
-
-        return $this;
+        return $this
+            ->setSearchableQuery($query)
+            ->buildQueryUsingWhereRelation($wheres, 'orWhereRelation');
     }
 
     /**
@@ -277,7 +265,7 @@ trait Searchable
      */
     protected function getSearchableQueryBuilder(EloquentBuilder $givenQuery = null)
     {
-        $this->setQuery($givenQuery);
+        $this->setSearchableQuery($givenQuery);
 
         return !empty($this->queryBuilder) ?
             $this->queryBuilder :
@@ -288,15 +276,17 @@ trait Searchable
      * Set the given query according to its type.
      *
      * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|null  $query
-     * @return void
+     * @return $this
      */
-    protected function setQuery($query = null)
+    public function setSearchableQuery($query = null)
     {
         if ($query instanceof EloquentBuilder) {
             $this->queryBuilder = $query->getQuery();
         } elseif ($query instanceof QueryBuilder) {
             $this->queryBuilder = $query;
         }
+
+        return $this;
     }
 
     /**

--- a/src/Updatable.php
+++ b/src/Updatable.php
@@ -73,7 +73,9 @@ trait Updatable
     /**
      * Delete records from the database.
      *
-     * @param  bool  $usingQueryBuilder
+     * @param  bool  $usingQueryBuilder  Whether to use the query builder to perform the delete.
+     *                                   If true, the delete will bypass any soft deletes and
+     *                                   permanently delete the records.
      * @return int
      *
      * @throws \Ramadan\EasyModel\Exceptions\InvalidModel

--- a/src/Updatable.php
+++ b/src/Updatable.php
@@ -261,11 +261,10 @@ trait Updatable
     {
         $model = $this->getUpdatableModel();
 
+        // If the developer has set a model for update, it takes precedence.
         if (!empty($model) && $model->exists) {
             $this->modelForUpdate = $model;
-        }
-
-        if (empty($this->searchOrUpdateQuery)) {
+        } elseif (empty($this->searchOrUpdateQuery)) {
             $this->searchOrUpdateQuery = $this->getSearchOrUpdateBuilder(isQueryBuilder: $usingQueryBuilder);
         }
     }

--- a/src/Updatable.php
+++ b/src/Updatable.php
@@ -228,10 +228,6 @@ trait Updatable
      */
     protected function getSearchOrUpdateQuery(string $relationship = null, bool $isQueryBuilder = false)
     {
-        if (!empty($this->searchOrUpdateQuery)) {
-            return $this->searchOrUpdateQuery;
-        }
-
         // If the "setRelationship" method exists, it means the request is coming
         // from the "Searchable" context since the "Updatable" trait is used there.
         if (!empty($relationship) && method_exists($this, 'setRelationship')) {
@@ -280,12 +276,13 @@ trait Updatable
     /**
      * Fetch the result.
      *
+     * @param  bool  $usingQueryBuilder
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
      *
      * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
      */
-    public function fetch()
+    public function fetch(bool $usingQueryBuilder = false)
     {
-        return $this->appliedChanges?->refresh() ?? $this->getSearchOrUpdateQuery()->get();
+        return $this->appliedChanges?->refresh() ?? $this->fetchBuilder($usingQueryBuilder)->get();
     }
 }

--- a/src/Updatable.php
+++ b/src/Updatable.php
@@ -88,10 +88,6 @@ trait Updatable
      *
      * @param  array  $attributes
      * @param  bool  $usingQueryBuilder
-     *
-     * The "usingQueryBuilder" parameter works only with the builder, not with a model instance
-     * that gets back when you call methods like "updateOrCreateModel".
-     *
      * @return $this
      *
      * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
@@ -129,10 +125,6 @@ trait Updatable
      *
      * @param  array  $attributes
      * @param  bool  $usingQueryBuilder
-     *
-     * The "usingQueryBuilder" parameter works only with the builder, not with a model instance
-     * that gets back when you call methods like "updateOrCreateModel".
-     *
      * @return $this
      *
      * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
@@ -170,10 +162,6 @@ trait Updatable
      *
      * @param  array  $attributes
      * @param  bool  $usingQueryBuilder
-     *
-     * The "usingQueryBuilder" parameter works only with the builder, not with a model instance
-     * that gets back when you call methods like "updateOrCreateModel".
-     *
      * @return $this
      *
      * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
@@ -200,10 +188,6 @@ trait Updatable
      *
      * @param  array  $attributes
      * @param  bool  $usingQueryBuilder
-     *
-     * The "usingQueryBuilder" parameter works only with the builder, not with a model instance
-     * that gets back when you call methods like "updateOrCreateModel".
-     *
      * @return $this
      *
      * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
@@ -224,8 +208,8 @@ trait Updatable
 
         $this->setSearchOrUpdateQuery($usingQueryBuilder);
 
-        $toggle = $this->searchOrUpdateQuery->get($attributes)->map(function (Model $attribute) {
-            return array_map(fn($value) => !$value, $attribute->toArray());
+        $toggle = $this->searchOrUpdateQuery->get($attributes)->map(function (Model $model) {
+            return array_map(fn($value) => !$value, $model->toArray());
         })->toArray();
 
         if (!empty($toggle)) {

--- a/src/Updatable.php
+++ b/src/Updatable.php
@@ -277,7 +277,7 @@ trait Updatable
      * Fetch the result.
      *
      * @param  bool  $usingQueryBuilder
-     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection
      *
      * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
      */

--- a/src/Updatable.php
+++ b/src/Updatable.php
@@ -84,57 +84,6 @@ trait Updatable
     }
 
     /**
-     * Create or update a record matching the attributes against the model, and fill it with values.
-     *
-     * @param  array  $attributes
-     * @param  array  $values
-     * @param  \Illuminate\Database\Eloquent\Model|string|null  $model
-     * @return $this
-     *
-     * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
-     */
-    public function updateOrCreateModel(array $attributes, array $values = [], $model = null)
-    {
-        if (!empty($model)) {
-            $this->setUpdatableModel($model);
-        }
-
-        $this->searchOrUpdateQuery = $this->getSearchOrUpdateQuery();
-
-        $this->appliedChanges = $this->searchOrUpdateQuery->updateOrCreate($attributes, $values);
-
-        return $this;
-    }
-
-    /**
-     * Create or update a record matching the attributes against the relationship, and fill it with values.
-     *
-     * @param  string  $relationship
-     * @param  array  $attributes
-     * @param  array  $values
-     * @param  \Illuminate\Database\Eloquent\Model|string|null  $model
-     * @return $this
-     *
-     * @throws \Ramadan\EasyModel\Exceptions\InvalidModel
-     */
-    public function updateOrCreateRelationship(
-        string $relationship,
-        array $attributes,
-        array $values = [],
-        $model = null
-    ) {
-        if (!empty($model)) {
-            $this->setUpdatableModel($model);
-        }
-
-        $this->searchOrUpdateQuery = $this->getSearchOrUpdateQuery($relationship);
-
-        $this->appliedChanges = $this->searchOrUpdateQuery->updateOrCreate($attributes, $values);
-
-        return $this;
-    }
-
-    /**
      * Increment the given column's values by the given amounts.
      *
      * @param  array  $attributes

--- a/src/Updatable.php
+++ b/src/Updatable.php
@@ -210,9 +210,11 @@ trait Updatable
 
         $this->setSearchOrUpdateQuery($usingQueryBuilder);
 
-        $this->searchOrUpdateQuery->update(
-            array_map(fn($attribute) => [$attribute => DB::raw("NOT $attribute")], $attributes)[0]
-        );
+        $columns = collect($attributes)
+            ->mapWithKeys(fn($attribute) => [$attribute => DB::raw("NOT $attribute")])
+            ->toArray();
+
+        $this->searchOrUpdateQuery->update($columns);
 
         return $this;
     }

--- a/src/Updatable.php
+++ b/src/Updatable.php
@@ -2,7 +2,7 @@
 
 namespace Ramadan\EasyModel;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 use Ramadan\EasyModel\Concerns\Update\HasModel as UpdatableModel;
 use Ramadan\EasyModel\Exceptions\InvalidModel;
 
@@ -208,13 +208,9 @@ trait Updatable
 
         $this->setSearchOrUpdateQuery($usingQueryBuilder);
 
-        $toggle = $this->searchOrUpdateQuery->get($attributes)->map(function (Model $model) {
-            return array_map(fn($value) => !$value, $model->toArray());
-        })->toArray();
-
-        if (!empty($toggle)) {
-            $this->searchOrUpdateQuery->update(...$toggle);
-        }
+        $this->searchOrUpdateQuery->update(
+            array_map(fn($attribute) => [$attribute => DB::raw("NOT $attribute")], $attributes)[0]
+        );
 
         return $this;
     }

--- a/src/Updatable.php
+++ b/src/Updatable.php
@@ -218,7 +218,7 @@ trait Updatable
     }
 
     /**
-     * Get an appropriate builder based on the context ("Searchable" or "Updatable").
+     * Get an appropriate builder based on the context "Searchable" or "Updatable".
      *
      * @param  string|null  $relationship
      * @param  bool  $isQueryBuilder
@@ -246,7 +246,7 @@ trait Updatable
     }
 
     /**
-     * Set the builder for the current context ("Searchable" or "Updatable").
+     * Set the builder for the current context "Searchable" or "Updatable".
      *
      * @param  bool  $usingQueryBuilder
      * @return void

--- a/src/Updatable.php
+++ b/src/Updatable.php
@@ -3,6 +3,8 @@
 namespace Ramadan\EasyModel;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Ramadan\EasyModel\Concerns\Update\HasModel as UpdatableModel;
 use Ramadan\EasyModel\Exceptions\InvalidModel;
 
@@ -260,6 +262,23 @@ trait Updatable
         if (empty($this->searchOrUpdateQuery)) {
             $this->searchOrUpdateQuery = $this->getSearchOrUpdateQuery(isQueryBuilder: $usingQueryBuilder);
         }
+    }
+
+    /**
+     * Set the given query according to its type.
+     *
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|null  $query
+     * @return $this
+     */
+    public function setUpdatableQuery($query = null)
+    {
+        if ($query instanceof EloquentBuilder) {
+            $this->searchOrUpdateQuery = $query->getQuery();
+        } elseif ($query instanceof QueryBuilder) {
+            $this->searchOrUpdateQuery = $query;
+        }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This PR is an add-on over #16 and #17, which introduces the following features and improvements:

- Removes the `updateOrCreateModel` and `updateOrCreateRelationship` methods.
- Fixes the issue of toggling many columns at a bunch of records.
- Adds the ability to specify the builder type that is returned.
- Removes the `setChainableModel` method.
- Updates the return type of the `setUpdatableModel` method.
- Fixes the issue of updating single model instances.
- Adds the `setSearchableQuery` method.
- Adds the `setUpdatableQuery` method.